### PR TITLE
Update h54s.sas

### DIFF
--- a/sasautos/h54s.sas
+++ b/sasautos/h54s.sas
@@ -338,6 +338,13 @@ options NOQUOTELENMAX LRECL=32000 spool;
             currentpairnum + 1 ;
           end ;
           output;
+          /* set all vars back to missing to prevent retained
+             SAS values when parsing incomplete JSON records  */
+          call missing (%sysfunc(tranwrd(
+            %sysfunc(compbl(
+              &string_colnames &num_colnames &date_colnames
+            )),%str( ),%str(,))
+          ));
           call prxnext(rowregexid, rowstart, rowstop, jsonString, rowpos, rowlen) ;
         end ;
         keep &string_colnames. &num_colnames. &date_colnames. ;


### PR DESCRIPTION
Discovered today that the HandsOnTable js library may create partial records (eg for new rows, will contain just the new / added cell values).  So the JSON produced from the hot object is not guaranteed to have every variable for every row.  When reading into SAS this was resulting in dataset variables being retained from the previous row (implicit behaviour due to use of output statement). 

The above fix prevents the (SAS side) data being corrupted in such a fashion and ensures missing variables are set to missing.