### PR TITLE
read date column from client

### DIFF
--- a/sasautos/h54s.sas
+++ b/sasautos/h54s.sas
@@ -144,6 +144,9 @@ run;
               when ('string') do;
                 indef=cats(varname,':$',scan(lenspec, 3, ','),'.');
               end;
+              when ('date') do;
+                indef=varname!!':best.';
+              end;
           end;
 
           /* input statement to macro */


### PR DESCRIPTION
If a client send a 'date' spec SAS will crash during the `bafGetDatasets` macro, because the select does not contain neither 'date' nor `otherwise` statement.