### PR TITLE
Compressed data support

### DIFF
--- a/sasautos/h54s.sas
+++ b/sasautos/h54s.sas
@@ -145,7 +145,7 @@ run;
                 indef=cats(varname,':$',scan(lenspec, 3, ','),'.');
               end;
               when ('date') do;
-                if ( &h54sdates ne ); then;
+                if ( &h54sdates eq ); then;
                   indef=varname!!':best.';
                 end;
               end;

--- a/sasautos/h54s.sas
+++ b/sasautos/h54s.sas
@@ -70,7 +70,7 @@ run;
 %mend;
 
 
-%macro bafGetDatasets(h54sdates=);
+%macro bafGetDatasets();
   %bafCheckDebug;
   /* quieten down the log unless we are debugging */
   %if (&h54sDeveloperMode ne 1) %then %bafQuietenDown;
@@ -145,9 +145,7 @@ run;
                 indef=cats(varname,':$',scan(lenspec, 3, ','),'.');
               end;
               when ('date') do;
-                if ( &h54sdates eq ); then;
-                  indef=varname!!':best.';
-                end;
+                indef=varname!!':best.';
               end;
           end;
 


### PR DESCRIPTION
This is an implementation of the suggestion that  @Ices-Eyes made in #58 

From the updated documentation:

> ## %bafOutDataset(objectName, libn, dsn, h54skeys=);
> 
> This macro serialises a SAS dataset to a JavaScript data object.
> 
> `objectName` is the name of the target JS object that the table will be serialised into
> 
> `libn` is the libname of the dataset to be serialised and transmitted to the frontend
> 
> `dsn` is the name of the dataset itself
> 
> `h54skeys` is an optional parameter that controls the output format of the data. By default, the data will be returned as a `key => value` object. When this option is turned on with `%bafOutDataset(class, work, class, h54skeys=nokeys);` then the data is returned as an array of arrays: array[0] is the metadata of the table and array[1] is the actual data.

Closes #84.